### PR TITLE
Merge Bug Fix 10: Not Properly Working with Tasks Plugin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -69,31 +69,35 @@ export default class VerticalTimelineListPlugin extends Plugin {
     );
 
     this.registerMarkdownPostProcessor((el) => {
-			// Find vertical timeline list
-      el.querySelectorAll('li[data-task="t"]').forEach((parent) => {
-        parent.addClass("vertical-timeline-list");
+			// Do initial mutation of timeline elements
+      mutateTimelineElements(el);
 
-				// Find vertical timeline bullets that are collapsible
-				parent.querySelectorAll(
-					":scope > ul.has-list-bullet > li > span.list-collapse-indicator.collapse-indicator.collapse-icon"
-				).forEach((indicator) => {
-					const bullet = indicator.previousElementSibling;
-					if (bullet?.matches("span.list-bullet")) {
-						bullet.addClass("vertical-timeline-list-collapsible-bullet");
-					}
-				});
-
-				// Remove collapse icons within timeline
-				parent.querySelectorAll(
-						":scope > ul.has-list-bullet span.list-collapse-indicator.collapse-indicator.collapse-icon > svg"
-					).forEach((svg) => {
-						svg.remove();
-					});
-
-				// Remove ability to collapse any children within timeline bullets
-				parent.querySelectorAll(":scope > ul.has-list-bullet li ul.has-list-bullet span.list-collapse-indicator.collapse-indicator.collapse-icon").forEach((span) => {
-					span.addClass("vertical-timeline-list-collapse-disabled");
+			// Create observer to trigger on newly added nodes
+			// Re-run mutation on added nodes injected by other plugins
+			// Fix specifically for Tasks plugin to work properly with this plugin
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((m) => {
+          m.addedNodes.forEach((node) => {
+            if (!(node instanceof HTMLElement)) return;
+            if (node.matches('li[data-task="t"]') || node.querySelector('li[data-task="t"]')) {
+              mutateTimelineElements(node);
+            }
+          });
         });
+      });
+      observer.observe(el, { childList: true, subtree: true });
+
+			// Remove observer once finished
+      const detachObserver = new MutationObserver(() => {
+        if (!el.isConnected) {
+          observer.disconnect();
+          detachObserver.disconnect();
+        }
+      });
+      detachObserver.observe(document.body, { childList: true, subtree: true });
+      this.register(() => {
+        observer.disconnect();
+        detachObserver.disconnect();
       });
     });
 
@@ -111,3 +115,41 @@ export default class VerticalTimelineListPlugin extends Plugin {
     await this.saveData(this.settings);
   }
 }
+
+//#region Utilitis
+
+function mutateTimelineElements(root: ParentNode): void {
+  const timelineCandidates: Element[] = Array.from(
+    root.querySelectorAll('li[data-task="t"]:not(.vertical-timeline-list)')
+  );
+
+	// If root is candidate, add to list
+  if (root instanceof Element
+      && root.matches('li[data-task="t"]:not(.vertical-timeline-list)')) timelineCandidates.unshift(root);
+
+	// Add classes to candidates
+  timelineCandidates.forEach((parent) => {
+		// Add class to vertical timeline list parent
+    parent.addClass("vertical-timeline-list");
+
+		// Find vertical timeline bullets that are collapsible
+    parent.querySelectorAll(":scope > ul.has-list-bullet > li > span.list-collapse-indicator.collapse-indicator.collapse-icon").forEach((indicator) => {
+      const bullet = indicator.previousElementSibling;
+      if (bullet?.matches("span.list-bullet")) {
+        bullet.addClass("vertical-timeline-list-collapsible-bullet");
+      }
+    });
+
+		// Remove collapse icons within timeline
+    parent.querySelectorAll(":scope > ul.has-list-bullet span.list-collapse-indicator.collapse-indicator.collapse-icon > svg").forEach((svg) => {
+      svg.remove();
+    });
+
+		// Remove ability to collapse any children within timeline bullets
+    parent.querySelectorAll(":scope > ul.has-list-bullet li ul.has-list-bullet span.list-collapse-indicator.collapse-indicator.collapse-icon").forEach((span) => {
+      span.addClass("vertical-timeline-list-collapse-disabled");
+    });
+  });
+}
+
+//#endregion

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,7 @@ export default class VerticalTimelineListPlugin extends Plugin {
       const observer = new MutationObserver((mutations) => {
         mutations.forEach((m) => {
           m.addedNodes.forEach((node) => {
-            if (!(node instanceof HTMLElement)) return;
+            if (!node.instanceOf(HTMLElement)) return;
             if (node.matches('li[data-task="t"]') || node.querySelector('li[data-task="t"]')) {
               mutateTimelineElements(node);
             }
@@ -94,7 +94,7 @@ export default class VerticalTimelineListPlugin extends Plugin {
           detachObserver.disconnect();
         }
       });
-      detachObserver.observe(document.body, { childList: true, subtree: true });
+      detachObserver.observe(el.ownerDocument.body, { childList: true, subtree: true });
       this.register(() => {
         observer.disconnect();
         detachObserver.disconnect();
@@ -124,7 +124,7 @@ function mutateTimelineElements(root: ParentNode): void {
   );
 
 	// If root is candidate, add to list
-  if (root instanceof Element
+  if (root.instanceOf(Element)
       && root.matches('li[data-task="t"]:not(.vertical-timeline-list)')) timelineCandidates.unshift(root);
 
 	// Add classes to candidates


### PR DESCRIPTION
## Summary

Obsidian recently added some additional rules to their linter that caused several warnings to be raised when using the `!important` CSS flag and `:has()` CSS selector.  To fix these issues, changes were made to the Vertical Timeline List plugin that added class injection into the task list elements in order to apply CSS styling needed to render the vertical timeline list and to allow for the removal of all the `!important` CSS flags and all the `:has()` CSS selectors. These specific changes caused the plugin to no longer render the vertical timeline list when using the Tasks plugin. 

Looking into the Tasks plugin's code I was able to determine the issue. The Tasks plugin rebuilds `<li>` elements for tasks it takes care of during their own markdown post-processing. This intended feature causes elements that may have injected classes into a task `<li>` element to be discarded, along with any attributes as well, removing the vertical timeline. 

An issue [(#3898)](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3898) has been created in the Tasks plugin repo to address the issue on their end. This PR is specifically to prevent future similar issues with other plugins from occurring.

## Related issue

Fixes #10 

## Root cause

Obsidian doesn't guarantee an ordering between markdown post-processors from different plugins. More importantly, any plugin's post-processor is free to discard and replace the very DOM elements an earlier post-processor mutated. When this occurs, every class, attribute, or transformation a previous post-processor added is thrown away with the original element. Because the plugin load order, post-processor registration order, and individual plugins' rendering strategies are all outside this plugin's control, relying on "we ran, therefore our changes persist" is not safe.

## The fix

This PR adds a `MutationObserver` per rendered chunk that re-applies the timeline transformations whenever a matching task `<li>` element is inserted into the subtree. This makes the plugin resilient to any other plugin (now or future) that swaps, rebuilds, or otherwise re-inserts task `<li>` elements after we've mutated them. The observers self-disconnect when the rendered chunk leaves the DOM, with an unload fallback to ensure no leaks.

## How to verify

Reproducing the bug:
1. Checkout `master` branch or download assets for release 3.0.2 and install the plugin into the test vault's `.obsidian/plugins/` directory.
2. In Obsidian enable the Vertical Timeline List plugin.
3. Install the Tasks plugin, version 8.2.0, and enable.
4. Create a new note containing a vertical timeline list task with at least one nested item. For example:
```
- [t] 
  - First entry
  - Second entry
 ```
 5. Switch to Reading View.
 6. Open the Developer Tools (Ctrl+Shift+I for Windows or Cmd+Opt+I for Mac) and navigate to the elements tab. Inspect the page to find the `<li data-task="t">` element for the vertical timeline list. Observe it is missing the `vertical-timeline-list` class that should have been added by the plugin.
 7. Disable the Tasks plugin.
 8. Reload Obsidian.
 9. In Developer Tools re-inspect to find the `<li data-task="t">` element and observe it now has the `vertical-timeline-list` class.

To verify the fix:
1. Checkout the `bug/10-Not_Properly_Working_with_Tasks_Plugin` branch and install the plugin into the test vault's `.obsidian/plugins/` directory.
2. Re-enable the Tasks plugin.
3. Open the same note in Reading View.
4. In Developer Tools re-inspect to find the `<li data-task="t">` element and observe it now has the `vertical-timeline-list` class.

## Regression risk

There is possibly a subtle performance degradation in heavy notes due to the `el.ownerDocument.body` detach watcher firing on every DOM mutation. This was not observed during testing and a narrowing of the detach watcher's scope from the `el.ownerDocument.body` to a closer ancestor of `el` could mitigate this.

Though not observed during testing, there is the possibility of a stale observer from a re-render handoff edge case, accumulating over a long session. Worst case, the `this.register` plugin unload still cleans everything up.

## Screenshots / recordings

Before Fix Tasks Enabled:
https://github.com/user-attachments/assets/439b7649-27ba-48b3-8072-7ad7f83c7f5a

Before Fix Tasks Disabled:
https://github.com/user-attachments/assets/c30568d0-d9c1-4261-a5b6-0a9a3531b029

After Fix Tasks Enabled:
https://github.com/user-attachments/assets/f804ee61-663c-4138-82ef-63994835a6cb

## Checklist

- [x] I have read the [contributing guidelines](../../CONTRIBUTING.md).
- [x] This PR is linked to a bug report issue.
- [x] I have reproduced the bug before this change and confirmed it no longer occurs after.
- [x] `npm run lint` passes.
- [x] `npm run build` passes with no TypeScript errors.
- [x] I have tested with existing timelines to confirm no regression.
- [x] I have verified the fix in both light and dark mode (if the bug is visual).
- [x] I have tested the fix on both the Obsidian desktop application and the Obsidian mobile app (if relevant).
